### PR TITLE
Correct Matrix Multiplication Dimensions

### DIFF
--- a/lec3a/matrix_operations.cc
+++ b/lec3a/matrix_operations.cc
@@ -26,7 +26,7 @@ matrix matrix::mult ( const matrix &m ) const {
     throw matrix_exception("Attemped to multiple matrices with incompatible sizes");
   }
 
-  matrix M(rows(),columns());
+  matrix M(rows(),m.columns());
 
   for ( int i=0; i<rows(); i++ ) {
     for ( int j=0; j<m.columns(); j++ ) {


### PR DESCRIPTION
I believe A*B should have dimension A.rows x B.columns.
Current code has A.rows x A.columns.
